### PR TITLE
Modificando '.' por '_' no nome do container para evitar problemas

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    container_name: felipecavalca.dev
+    container_name: felipecavalca_dev
     build:
       context: ./app
       dockerfile: ./Dockerfile


### PR DESCRIPTION
Devido a problemas com o monitoramente foi substituido o '.' por '_'