### PR TITLE
Update 'Agora' section copy and add TraceSQL to projects in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,19 +95,19 @@
 
     <section id="agora" class="card reveal now-section">
       <h2>Agora</h2>
-      <p>Coisas em andamento neste momento, fora da lista oficial de projetos.</p>
+      <p>Estou dedicando meu tempo a construir ferramentas que resolvem problemas reais de desenvolvimento e performance.</p>
       <div class="now-grid">
         <article class="now-item">
-          <h3>Explorando</h3>
-          <p>Melhorias de UX para landing pages e componentes de alto reaproveitamento.</p>
+          <h3>Construindo agora</h3>
+          <p>Evoluindo o TraceSQL para facilitar a analise de queries, gargalos de banco e comportamento de consultas em producao.</p>
         </article>
         <article class="now-item">
-          <h3>Construindo</h3>
-          <p>Automacoes para deploy e padroes de base para novos repositorios.</p>
+          <h3>Melhorando processo</h3>
+          <p>Padronizando estrutura de projetos, automacoes de deploy e qualidade de codigo para acelerar entregas com seguranca.</p>
         </article>
         <article class="now-item">
-          <h3>Estudando</h3>
-          <p>Arquitetura para apps escalaveis e performance real em ambiente de producao.</p>
+          <h3>Objetivo</h3>
+          <p>Lancar versoes mais robustas dos meus projetos open source, com foco em documentacao clara e boa experiencia para devs.</p>
         </article>
       </div>
     </section>
@@ -119,6 +119,11 @@
           <h3>Xdebug Profiler Viewer</h3>
           <p>Extensao do VS Code para abrir, visualizar e navegar por perfis do Xdebug direto no editor.</p>
           <a href="https://github.com/Felipe-Cavalca/xdebug-profiler-viewer" aria-label="Abrir Xdebug Profiler Viewer">Abrir</a>
+        </li>
+        <li>
+          <h3>TraceSQL</h3>
+          <p>Ferramenta para rastrear e analisar queries SQL, ajudando a identificar gargalos e otimizar performance de banco de dados.</p>
+          <a href="https://github.com/Felipe-Cavalca/TraceSQL" aria-label="Abrir TraceSQL">Abrir</a>
         </li>
         <li>
           <h3>Dossier</h3>


### PR DESCRIPTION
### Motivation
- Improve the "Agora" section copy to better communicate current work, goals and project priorities. 
- Surface the new `TraceSQL` project in the featured projects list to increase visibility. 

### Description
- Updated `index.html` `#agora` intro paragraph to clearer, more action-oriented copy. 
- Replaced the three `.now-item` blocks with new headings and updated paragraphs (`Construindo agora`, `Melhorando processo`, `Objetivo`) to reflect current efforts and objectives. 
- Added a new project list item for `TraceSQL` with a link to `https://github.com/Felipe-Cavalca/TraceSQL`.

### Testing
- No automated tests were run for this static HTML content change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd29576598832f9883bf06c8355b14)