### PR TITLE
Revamp `.project-list` cards: layout, styling, hover/focus and responsive behavior

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -284,29 +284,85 @@ h1 {
 
 .project-list {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 0.9rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+  align-items: stretch;
 }
 
 .project-list li {
-  border: 1px dashed var(--border);
-  border-radius: 14px;
-  padding: 0.9rem;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 1.05rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+  min-height: 196px;
+  background:
+    linear-gradient(140deg, rgba(255, 255, 255, 0.34), rgba(255, 255, 255, 0.15));
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.project-list li::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto auto 0;
+  width: 100%;
+  height: 2px;
+  background: linear-gradient(90deg, var(--accent), transparent 70%);
+  opacity: 0.8;
+}
+
+.project-list li:hover {
+  transform: translateY(-3px);
+  border-color: rgba(0, 0, 0, 0.14);
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.12);
+}
+
+.project-list li:focus-within {
+  border-color: rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 0 3px rgba(219, 58, 52, 0.2);
 }
 
 .project-list h3 {
   margin: 0;
+  line-height: 1.25;
 }
 
 .project-list p {
-  margin: 0.45rem 0 0.8rem;
+  margin: 0;
   color: var(--project-copy);
+  flex-grow: 1;
+  line-height: 1.65;
 }
 
 .project-list a,
 .contact-list a {
   color: var(--accent-dark);
   font-weight: 700;
+}
+
+.project-list a {
+  align-self: flex-start;
+  margin-top: auto;
+  text-decoration: none;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  padding: 0.3rem 0.72rem;
+  font-size: 0.9rem;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.project-list a:hover {
+  background: var(--accent-dark);
+  color: #fff;
+}
+
+.project-list a:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .contact-list {
@@ -455,6 +511,25 @@ h1 {
       linear-gradient(135deg, rgba(23, 34, 50, 0.65), rgba(12, 19, 29, 0.48));
   }
 
+  .project-list li {
+    background:
+      linear-gradient(140deg, rgba(22, 33, 48, 0.7), rgba(14, 22, 33, 0.45));
+  }
+
+  .project-list li:hover {
+    border-color: rgba(230, 239, 255, 0.28);
+    box-shadow: 0 16px 32px rgba(2, 6, 14, 0.55);
+  }
+
+  .project-list li:focus-within {
+    border-color: rgba(230, 239, 255, 0.35);
+    box-shadow: 0 0 0 3px rgba(255, 123, 84, 0.24);
+  }
+
+  .project-list a:hover {
+    color: #111a26;
+  }
+
   @keyframes sectionFlash {
     0% {
       transform: translateY(0);
@@ -503,6 +578,16 @@ h1 {
 
   .support-modal-card {
     border-radius: 16px;
+  }
+
+  .project-list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 520px) {
+  .project-list {
+    grid-template-columns: 1fr;
   }
 }
 


### PR DESCRIPTION
### Motivation

- Improve the visual design and usability of the project cards by updating spacing, card geometry, and interactive states for a more modern look. 
- Increase accessibility and clarity of interactive elements by adding focus states and clearer call-to-action styling. 
- Make the projects grid more consistent and responsive across viewport sizes.

### Description

- Updated the `.`project-list` grid to use a larger minimum column width, increased gap, added `margin-top`, and set `align-items: stretch` for even card sizing. 
- Overhauled `.`project-list li` card styling by switching to a solid border, larger border-radius, increased padding, `display: flex` with column layout and a `min-height`, added a subtle gradient background, transition effects, and a decorative `::before` stripe. 
- Added interactive states including hover elevation (`transform` and `box-shadow`) and `:focus-within` outlines, plus adjusted dark-mode variants for these states. 
- Restyled card copy and headings by tuning margins, line-height, and making the project description grow to fill available space, and introduced pill-like CTA styling for `.`project-list a` with hover and focus-visible behaviors. 
- Added responsive rules to collapse the grid to two columns below `640px` and to a single column below `520px`.

### Testing

- No automated tests were added or executed for this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd547c4bac832f896ce1047e820fe4)