### PR TITLE
Corrigir experiência mobile do redesign

### DIFF
--- a/mobile.css
+++ b/mobile.css
@@ -1,0 +1,482 @@
+@media (max-width: 620px) {
+  :root {
+    --mobile-gutter: 1rem;
+  }
+
+  body {
+    background:
+      radial-gradient(circle at 75% 8%, rgba(255, 107, 74, .1), transparent 20rem),
+      var(--bg);
+  }
+
+  .ambient {
+    width: 22rem;
+    height: 22rem;
+    filter: blur(90px);
+    opacity: .08;
+  }
+
+  .site-header {
+    top: .55rem;
+    width: calc(100% - 1rem);
+    height: 3.2rem;
+    padding: .45rem .55rem .45rem .65rem;
+  }
+
+  .brand {
+    gap: .5rem;
+    min-width: 0;
+  }
+
+  .brand img {
+    width: 1.65rem;
+    height: 1.65rem;
+  }
+
+  .brand span {
+    display: inline;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-size: .86rem;
+  }
+
+  .nav a {
+    display: none;
+  }
+
+  .nav a:first-child {
+    display: inline-flex;
+    padding: .5rem .7rem;
+    font-size: .76rem;
+  }
+
+  .hero {
+    width: calc(100% - (var(--mobile-gutter) * 2));
+    min-height: 100svh;
+    padding: 5.7rem 0 2.2rem;
+    justify-content: flex-start;
+  }
+
+  .hero .kicker {
+    order: 1;
+    margin-bottom: .8rem;
+  }
+
+  .hero h1 {
+    order: 2;
+    max-width: none;
+    font-size: clamp(2.85rem, 13.4vw, 4.2rem);
+    line-height: .91;
+    letter-spacing: -.062em;
+  }
+
+  .hero-orbit {
+    position: relative;
+    order: 3;
+    top: auto;
+    right: auto;
+    width: min(68vw, 17rem);
+    margin: 1.35rem auto 1.1rem;
+    opacity: .72;
+    transform: none;
+    flex: 0 0 auto;
+  }
+
+  .orbit-ring {
+    border-color: rgba(255, 255, 255, .14);
+  }
+
+  .orbit-ring::after {
+    width: .62rem;
+    height: .62rem;
+  }
+
+  .orbit-core {
+    box-shadow: 0 0 54px rgba(255, 107, 74, .22);
+  }
+
+  .hero-copy {
+    order: 4;
+    max-width: none;
+    margin: 0;
+    font-size: .96rem;
+    line-height: 1.55;
+  }
+
+  .hero-actions {
+    order: 5;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    width: 100%;
+    margin-top: 1.35rem;
+    gap: .55rem;
+  }
+
+  .hero-actions .button {
+    width: 100%;
+    min-height: 2.85rem;
+    padding-inline: .8rem;
+    font-size: .88rem;
+  }
+
+  .scroll-cue {
+    display: none;
+  }
+
+  .story {
+    height: 330vh;
+  }
+
+  .story-sticky {
+    width: calc(100% - (var(--mobile-gutter) * 2));
+    height: 100svh;
+    padding: 5rem 0 .8rem;
+    display: grid;
+    grid-template-rows: auto minmax(0, 1fr);
+    align-content: stretch;
+    gap: .9rem;
+  }
+
+  .story-copy {
+    min-height: 0;
+  }
+
+  .story-copy .kicker {
+    margin-bottom: .55rem;
+  }
+
+  .story-lines {
+    min-height: 8.8rem;
+  }
+
+  .story-line {
+    max-width: 100%;
+    font-size: clamp(2rem, 9.5vw, 2.8rem);
+    line-height: .96;
+    letter-spacing: -.052em;
+  }
+
+  .story-visual {
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+    margin: 0;
+    align-self: stretch;
+  }
+
+  .visual-shell {
+    height: 100%;
+    min-height: 17rem;
+    aspect-ratio: auto;
+    border-radius: 1.4rem;
+    transform: scale(calc(.965 + (var(--story-progress) * .035)));
+    box-shadow: 0 28px 70px rgba(0, 0, 0, .38);
+  }
+
+  .visual-topbar {
+    height: 2.6rem;
+    padding-inline: .9rem;
+  }
+
+  .visual-stage {
+    inset: 2.6rem 0 0;
+  }
+
+  .visual-stage::before {
+    background-size: 2.15rem 2.15rem;
+  }
+
+  .code-line {
+    height: .42rem;
+  }
+
+  .metric {
+    min-width: 5.4rem;
+    padding: .62rem;
+    border-radius: .75rem;
+  }
+
+  .metric strong {
+    font-size: .94rem;
+  }
+
+  .metric span {
+    font-size: .58rem;
+  }
+
+  .metric-a { left: 7%; bottom: 8%; }
+  .metric-b { right: 7%; top: 31%; }
+  .metric-c { right: 14%; bottom: 9%; }
+
+  .section {
+    width: calc(100% - (var(--mobile-gutter) * 2));
+    padding: 5.5rem 0;
+  }
+
+  .section-heading {
+    margin-bottom: 2.4rem;
+  }
+
+  .section-heading h2,
+  .contact h2 {
+    font-size: clamp(2.55rem, 11.8vw, 3.7rem);
+    line-height: .94;
+  }
+
+  .project-story {
+    height: 450vh;
+  }
+
+  .projects-sticky {
+    width: calc(100% - (var(--mobile-gutter) * 2));
+    height: 100svh;
+    padding: 4.65rem 0 .65rem;
+    grid-template-rows: auto minmax(0, 1fr);
+    gap: .7rem;
+  }
+
+  .project-story-header {
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: .65rem;
+    align-items: end;
+  }
+
+  .project-story .section-heading {
+    max-width: 17rem;
+  }
+
+  .project-story .section-heading .kicker {
+    margin-bottom: .3rem;
+  }
+
+  .project-story .section-heading h2 {
+    font-size: clamp(1.75rem, 7.9vw, 2.35rem);
+    line-height: .94;
+    letter-spacing: -.05em;
+  }
+
+  .project-story-status {
+    padding-bottom: .15rem;
+    font-size: .64rem;
+  }
+
+  .project-stage {
+    min-height: 0;
+  }
+
+  .project-story .project {
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(0, 1.16fr) minmax(9.8rem, .84fr);
+    border-radius: 1.25rem;
+    transform: translate3d(0, 5vh, -35px) scale(.98);
+  }
+
+  .project-story .project.is-before {
+    transform: translate3d(0, -4vh, -45px) scale(.975);
+  }
+
+  .project-story .project.is-after {
+    transform: translate3d(0, 5vh, -35px) scale(.98);
+  }
+
+  .project-story .project-copy {
+    padding: 1.15rem 1.1rem .8rem;
+    overflow: hidden;
+  }
+
+  .project-story .project-index {
+    margin-bottom: .52rem;
+    font-size: .62rem;
+  }
+
+  .project-story .project h3 {
+    max-width: none;
+    font-size: clamp(1.95rem, 9vw, 2.7rem);
+    line-height: .94;
+  }
+
+  .project-story .project-copy > p:not(.project-index) {
+    margin: .58rem 0 0;
+    font-size: .82rem;
+    line-height: 1.42;
+  }
+
+  .project-story .project-tags {
+    gap: .35rem;
+    margin: .58rem 0 .65rem;
+  }
+
+  .project-story .project-tags span {
+    padding: .27rem .42rem;
+    font-size: .56rem;
+  }
+
+  .project-story .text-link {
+    margin-top: auto;
+    font-size: .82rem;
+  }
+
+  .project-story .project-art {
+    min-height: 0;
+  }
+
+  .terminal-window {
+    width: 88%;
+    border-radius: .8rem;
+  }
+
+  .terminal-header {
+    padding: .55rem .75rem;
+    font-size: .6rem;
+  }
+
+  .terminal-window code {
+    padding: .42rem .8rem 0;
+    font-size: .67rem;
+  }
+
+  .profiler-panel {
+    width: 88%;
+    gap: .65rem;
+    padding: .85rem;
+    border-radius: .9rem;
+  }
+
+  .profiler-row {
+    grid-template-columns: 4.25rem 1fr;
+    gap: .55rem;
+    font-size: .58rem;
+  }
+
+  .profiler-row i {
+    height: .46rem;
+  }
+
+  .money-orbit {
+    width: 48%;
+  }
+
+  .money-orbit-b {
+    width: 31%;
+  }
+
+  .money-core {
+    width: 6.7rem;
+  }
+
+  .money-core strong {
+    font-size: 1.45rem;
+  }
+
+  .money-core span {
+    font-size: .54rem;
+  }
+
+  .node {
+    padding: .48rem .58rem;
+    border-radius: .6rem;
+    font-size: .56rem;
+  }
+
+  .now {
+    padding-top: 4.8rem;
+  }
+
+  .now-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .now-card,
+  .now-card:nth-child(odd),
+  .now-card:nth-child(even) {
+    min-height: 0;
+    padding: 1.35rem 0 1.55rem;
+    border-right: 0;
+  }
+
+  .now-card h3 {
+    margin: 1.8rem 0 .35rem;
+    font-size: 1.75rem;
+  }
+
+  .now-card p {
+    font-size: .92rem;
+  }
+
+  .about-grid {
+    gap: 1.4rem;
+  }
+
+  .about-copy {
+    padding-top: 0;
+  }
+
+  .about-copy p {
+    font-size: .98rem;
+  }
+
+  .stack-line {
+    margin-top: 1.35rem;
+  }
+
+  .contact {
+    min-height: auto;
+    padding-top: 6rem;
+    padding-bottom: 6rem;
+  }
+
+  .contact-actions {
+    display: grid;
+    grid-template-columns: 1fr;
+    margin-top: 1.6rem;
+  }
+
+  .contact-actions .button {
+    width: 100%;
+  }
+
+  .support-card {
+    padding: 1.5rem 1.1rem 1.2rem;
+    border-radius: 1.25rem;
+  }
+
+  .site-footer {
+    width: calc(100% - (var(--mobile-gutter) * 2));
+    padding: 1.5rem 0 2.2rem;
+  }
+}
+
+@media (max-width: 390px) {
+  .brand span {
+    max-width: 7.4rem;
+  }
+
+  .hero h1 {
+    font-size: clamp(2.65rem, 13vw, 3.6rem);
+  }
+
+  .hero-orbit {
+    width: min(62vw, 14.5rem);
+    margin-block: 1.05rem .9rem;
+  }
+
+  .story-line {
+    font-size: clamp(1.9rem, 9vw, 2.45rem);
+  }
+
+  .project-story .section-heading {
+    max-width: 14.5rem;
+  }
+
+  .project-story .section-heading h2 {
+    font-size: 1.68rem;
+  }
+
+  .project-story .project h3 {
+    font-size: clamp(1.75rem, 8.4vw, 2.35rem);
+  }
+
+  .project-story .project-copy > p:not(.project-index) {
+    font-size: .78rem;
+  }
+}

--- a/script.js
+++ b/script.js
@@ -9,6 +9,7 @@ const copyPixBtn = document.getElementById("copy-pix");
 const copyStatus = document.getElementById("copy-status");
 const PIX_KEY = "pix@felipecavalca.dev";
 const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+const compactViewport = window.matchMedia("(max-width: 620px)");
 
 if (yearEl) yearEl.textContent = String(new Date().getFullYear());
 
@@ -38,12 +39,31 @@ function ensureProjectStoryStyles() {
   document.head.appendChild(link);
 }
 
+function ensureMobileStyles() {
+  if (document.querySelector('link[data-mobile-layout]')) return;
+  const link = document.createElement("link");
+  link.rel = "stylesheet";
+  link.href = "mobile.css";
+  link.media = "(max-width: 620px)";
+  link.dataset.mobileLayout = "";
+  document.head.appendChild(link);
+}
+
 ensureProjectStoryStyles();
+ensureMobileStyles();
 
 const projects = document.querySelector(".projects");
 let projectCards = [];
 let projectDots = [];
 let projectCurrent = null;
+
+function syncProjectStoryHeight() {
+  if (!projects || projectCards.length === 0 || prefersReducedMotion.matches) return;
+  const height = compactViewport.matches
+    ? projectCards.length * 95 + 70
+    : Math.max(500, projectCards.length * 115 + 80);
+  projects.style.height = `${height}vh`;
+}
 
 function setupProjectStory() {
   if (!projects || prefersReducedMotion.matches) return;
@@ -53,7 +73,7 @@ function setupProjectStory() {
   if (!heading || projectCards.length === 0) return;
 
   projects.classList.add("project-story");
-  projects.style.height = `${Math.max(500, projectCards.length * 115 + 80)}vh`;
+  syncProjectStoryHeight();
 
   heading.classList.remove("reveal", "visible");
   projectCards.forEach((card, index) => {
@@ -196,8 +216,14 @@ function requestScrollUpdate() {
   requestAnimationFrame(updateScrollScenes);
 }
 
+function handleResize() {
+  syncProjectStoryHeight();
+  requestScrollUpdate();
+}
+
 window.addEventListener("scroll", requestScrollUpdate, { passive: true });
-window.addEventListener("resize", requestScrollUpdate, { passive: true });
+window.addEventListener("resize", handleResize, { passive: true });
+compactViewport.addEventListener?.("change", handleResize);
 updateScrollScenes();
 
 function openSupportModal() {


### PR DESCRIPTION
## Resumo

Separa as correções mobile do redesign já mergeado no PR #6.

## Contexto

O desktop está aprovado. A versão mobile precisa de tratamento específico e está sendo acompanhada pela issue #8.

## Escopo

- reorganizar hero em telas pequenas;
- compactar header e navegação;
- adaptar `Construir é um processo` para `100svh`;
- ajustar cards e scroll storytelling dos projetos para 360–430px;
- reduzir sobreposição, overflow e animações pesadas no celular;
- manter o desktop sem alterações visuais.

Relacionado a #8.
